### PR TITLE
Removed deprecation warning.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "ecs_profile" {
     name = "tf-created-AmazonECSContainerProfile-${var.name}"
-    roles = ["${aws_iam_role.ecs-role.name}"]
+    role = "${aws_iam_role.ecs-role.name}"
 }
 
 resource "aws_iam_role" "ecs-role" {


### PR DESCRIPTION
```
There are warnings related to your configuration. If no errors occurred,
Terraform will continue despite these warnings. It is a good idea to resolve
these warnings in the near future.

Warnings:

  * module.ecs_cluster.aws_iam_instance_profile.ecs_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
```