### PR TITLE
Allow for multiple security groups to be applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ extra_tags = [
 - `ami` - specific AMI image to use, eg `ami-95f8d2f3`.
 - `ami_version` - specific version of the Amazon ECS AMI to use, eg `2016.09`
 - `heartbeat_timeout` - Heartbeat Timeout setting for how long it takes for the graceful shutodwn hook takes to timeout. This is useful when deploying clustered applications like consul that benifit from having a deploy between autoscaling create/destroy actions. Defaults to 180"
+- `security_group_ids` - a list of security group IDs to apply to the launch configuration
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_launch_configuration" "ecs" {
   instance_type        = "${var.instance_type}"
   key_name             = "${var.key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.ecs_profile.name}"
-  security_groups      = ${concat(["${aws_security_group.ecs.id}"], var.security_group_ids)}
+  security_groups      = ["${aws_security_group.ecs.id}", "${var.security_group_ids}"]
   associate_public_ip_address = "${var.associate_public_ip_address}"
   ebs_block_device {
     device_name = "/dev/xvdcz"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_launch_configuration" "ecs" {
   instance_type        = "${var.instance_type}"
   key_name             = "${var.key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.ecs_profile.name}"
-  security_groups      = ["${aws_security_group.ecs.id}"]
+  security_groups      = ${concat(["${aws_security_group.ecs.id}"], var.security_group_ids)}
   associate_public_ip_address = "${var.associate_public_ip_address}"
   ebs_block_device {
     device_name = "/dev/xvdcz"

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "region" {
   description = "The region of AWS, for AMI lookups."
 }
 
+variable "security_group_ids" {
+  type        = "list"
+  description = "A list of Security group IDs to apply to the launch configuration"
+  default     = []
+}
+
 variable "servers" {
   default     = "1"
   description = "The number of servers to launch."


### PR DESCRIPTION
It would be nice to have greater control over the instance security group, but it felt a bit fiddly passing in lots of config values to control each property. Instead it seems simpler to just define another security group elsewhere and just pass the ID in to this module and then apply multiple security groups to the instances.