### PR TITLE
Adds iam_path var to IAM Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ note about `user_data` and - `additional_user_data_script`: The `user_data` para
 - `region` - AWS Region - defaults to us-east-1
 - `servers`  - Number of ECS Servers to start in the cluster - defaults to 2
 - `instance_type` - AWS instance type - defaults to t2.micro
+- `iam_path` - IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /
 - `associate_public_ip_address` - assign a publicly-routable IP address to every instance in the cluster - default: `false`.
 - `docker_storage_size` - EBS Volume size in Gib that the ECS Instance uses for Docker images and metadata - defaults to 22
 - `dockerhub_email` - Email Address used to authenticate to dockerhub. http://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html

--- a/iam.tf
+++ b/iam.tf
@@ -1,10 +1,12 @@
 resource "aws_iam_instance_profile" "ecs_profile" {
   name = "tf-created-AmazonECSContainerProfile-${var.name}"
   role = "${aws_iam_role.ecs-role.name}"
+  path = "${var.iam_path}"
 }
 
 resource "aws_iam_role" "ecs-role" {
   name = "tf-AmazonECSInstanceRole-${var.name}"
+  path = "${var.iam_path}"
 
   assume_role_policy = <<EOF
 {
@@ -32,6 +34,7 @@ EOF
 resource "aws_iam_policy" "ecs-policy" {
   name        = "tf-created-AmazonECSContainerInstancePolicy-${var.name}"
   description = "A terraform created policy for ECS"
+  path        = "${var.iam_path}"
 
   policy = <<EOF
 {
@@ -94,7 +97,7 @@ data "aws_iam_policy_document" "assume_role_consul_task" {
 resource "aws_iam_role" "consul_task" {
   count              = "${var.enable_agents ? 1 : 0}"
   name               = "${replace(format("%.64s", replace("tf-consul-agentTaskRole-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-")), "/\\s/", "-")}"
-  path               = "/"
+  path               = "${var.iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_consul_task.json}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,11 @@ variable "heartbeat_timeout" {
   default     = "180"
 }
 
+variable "iam_path" {
+  default     = "/"
+  description = "IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /"
+}
+
 variable "instance_type" {
   default     = "t2.micro"
   description = "AWS Instance type, if you change, make sure it is compatible with AMI, not all AMIs allow all instance types "


### PR DESCRIPTION
This should be a backward compatable change, this adds the option to
define custum IAM paths, which is useful when creating IAM resources in
the same account across multiple regions, using the same name. So for
example if you have a "dev" ECS Cluster in us-east-1 and us-east-2