### PR TITLE
Add min_servers and max_servers variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ Module Input Variables
 - `vpc_id` - The VPC ID to place the cluster in
 
 #### Optional
-note about `user_data` and - `additional_user_data_script`: The `user_data` parameter overwrites the user_data template used by this module, this will break some of the module features. (`docker_storage_size`, `dockerhub_token`, and `dockerhub_email`) `additional_user_data_script` however will concatenate additional data to the end of the current user_data script. It is recomended that you use `additional_user_data_script`. These two parameters are mutually exclusive - you can not pass both into this module and expect it to work.
 
-- `additional_user_data_script` - Additional user_data scripts content
+**NOTE About User Data:** The `user_data` parameter overwrites the `user_data` template used by this module, this will break some of the module features (e.g. `docker_storage_size`, `dockerhub_token`, and `dockerhub_email`). However, `additional_user_data_script` will concatenate additional data to the end of the current `user_data` script. It is recomended that you use `additional_user_data_script`. These two parameters are mutually exclusive - you can not pass both into this module and expect it to work.
+
+- `additional_user_data_script` - Additional `user_data` scripts content
 - `region` - AWS Region - defaults to us-east-1
-- `servers`  - Number of ECS Servers to start in the cluster - defaults to 2
+- `servers`  - Number of ECS Servers to start in the cluster - defaults to 1
+- `min_servers`  - Minimum number of ECS Servers to start in the cluster - defaults to 1
+- `max_servers`  - Maximum number of ECS Servers to start in the cluster - defaults to 10
 - `instance_type` - AWS instance type - defaults to t2.micro
 - `iam_path` - IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /
 - `associate_public_ip_address` - assign a publicly-routable IP address to every instance in the cluster - default: `false`.

--- a/main.tf
+++ b/main.tf
@@ -55,8 +55,8 @@ resource "aws_autoscaling_group" "ecs" {
   name                 = "asg-${aws_launch_configuration.ecs.name}"
   vpc_zone_identifier  = ["${var.subnet_id}"]
   launch_configuration = "${aws_launch_configuration.ecs.name}"
-  min_size             = 1
-  max_size             = 10
+  min_size             = "${var.min_servers}"
+  max_size             = "${var.max_servers}"
   desired_capacity     = "${var.servers}"
   termination_policies = ["OldestLaunchConfiguration", "ClosestToNextInstanceHour", "Default"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,12 +70,12 @@ variable "key_name" {
 
 variable "min_servers" {
   description = "Minimum number of ECS servers to run."
-  default = 1
+  default     = 1
 }
 
 variable "max_servers" {
   description = "Maximum number of ECS servers to run."
-  default = 10
+  default     = 10
 }
 
 variable "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,16 @@ variable "key_name" {
   description = "SSH key name in your AWS account for AWS instances."
 }
 
+variable "min_servers" {
+  description = "Minimum number of ECS servers to run."
+  default = 1
+}
+
+variable "max_servers" {
+  description = "Maximum number of ECS servers to run."
+  default = 10
+}
+
 variable "name" {
   description = "AWS ECS Cluster Name"
 }


### PR DESCRIPTION
Allow people to set `min_servers` and `max_servers` variables. This will allow us to run 0 servers in staging for thinks like background workers. 