### PR TITLE
Use name_prefix so we can create_before_destroy.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_launch_configuration" "ecs" {
 }
 
 resource "aws_autoscaling_group" "ecs" {
-  name                 = "asg-${aws_launch_configuration.ecs.name}"
+  name_prefix          = "asg-${aws_launch_configuration.ecs.name}-"
   vpc_zone_identifier  = ["${var.subnet_id}"]
   launch_configuration = "${aws_launch_configuration.ecs.name}"
   min_size             = "${var.min_servers}"


### PR DESCRIPTION
When you try to `create_before_destroy` on some AWS resources, it will fail because you can't have two of them with the same name. ASGs, sadly, are one of them. For this reason, I always use `name_prefix`, if available, when I set `create_before_destroy = true`.

**WARNING:** This will cause any ASGs built with this module to be tainted on your next TF run. I'm not really sure I have a good solution to this problem. We're either left with `create_before_destroy` failing whenever an ASG changes _or_ dealing with the pain of a one-time event of recreating everything with `name_prefix`.