### PR TITLE
Allow consuming TF code to alter wait_for_capacity_timeout.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_launch_configuration" "ecs" {
 }
 
 resource "aws_autoscaling_group" "ecs" {
-  name                 = "asg-${aws_launch_configuration.ecs.name}"
+  name_prefix          = "asg-${aws_launch_configuration.ecs.name}-"
   vpc_zone_identifier  = ["${var.subnet_id}"]
   launch_configuration = "${aws_launch_configuration.ecs.name}"
   min_size             = "${var.min_servers}"

--- a/main.tf
+++ b/main.tf
@@ -84,10 +84,6 @@ resource "aws_autoscaling_group" "ecs" {
   lifecycle {
     create_before_destroy = true
   }
-
-  timeouts {
-    delete = "${var.autscaling_group_delete_timeout}"
-  }
 }
 
 resource "aws_security_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_launch_configuration" "ecs" {
 }
 
 resource "aws_autoscaling_group" "ecs" {
-  name                      = "asg-${aws_launch_configuration.ecs.name}"
+  name_prefix               = "asg-${aws_launch_configuration.ecs.name}-"
   vpc_zone_identifier       = ["${var.subnet_id}"]
   launch_configuration      = "${aws_launch_configuration.ecs.name}"
   min_size                  = "${var.min_servers}"

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,12 @@ variable "enable_agents" {
 }
 
 variable "extra_tags" {
+  type    = "list"
   default = []
+}
+
+variable "wait_for_capacity_timeout" {
+  default = "10m"
 }
 
 variable "heartbeat_timeout" {


### PR DESCRIPTION
Includes a default value of `10m`, which is TF's default as well. We have some ASGs that keep timing out when we adjust capacity. 