### PR TITLE
Adding policy actions for additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ extra_tags = [
 - `heartbeat_timeout` - Heartbeat Timeout setting for how long it takes for the graceful shutodwn hook takes to timeout. This is useful when deploying clustered applications like consul that benifit from having a deploy between autoscaling create/destroy actions. Defaults to 180"
 - `security_group_ids` - a list of security group IDs to apply to the launch configuration
 - `user_data` - The instance user data (e.g. a `cloud-init` config) to use in the `aws_launch_configuration`
--  use_custom_iam_policy - Bool to control usage of custom IAM policy
--  custom_iam_policy -  JSON containing the custom IAM policy for ECS nodes
+-  custom_iam_policy -  JSON containing the custom IAM policy for ECS nodes. Will overwrite the default one if set.
 
 - `consul_image` - Image to use when deploying consul, defaults to the hashicorp consul image
 - `registrator_image` - Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ extra_tags = [
 - `heartbeat_timeout` - Heartbeat Timeout setting for how long it takes for the graceful shutodwn hook takes to timeout. This is useful when deploying clustered applications like consul that benifit from having a deploy between autoscaling create/destroy actions. Defaults to 180"
 - `security_group_ids` - a list of security group IDs to apply to the launch configuration
 - `user_data` - The instance user data (e.g. a `cloud-init` config) to use in the `aws_launch_configuration`
+-  use_custom_iam_policy - Bool to control usage of custom IAM policy
+-  custom_iam_policy -  JSON containing the custom IAM policy for ECS nodes
 
 - `consul_image` - Image to use when deploying consul, defaults to the hashicorp consul image
 - `registrator_image` - Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest

--- a/iam.tf
+++ b/iam.tf
@@ -35,6 +35,7 @@ resource "aws_iam_policy" "ecs-policy" {
   name_prefix = "${replace(format("%.102s", replace("tf-ECSInPol-${var.name}-", "_", "-")), "/\\s/", "-")}"
   description = "A terraform created policy for ECS"
   path        = "${var.iam_path}"
+  count       = "${1 - var.use_custom_iam_policy}"
 
   policy = <<EOF
 {
@@ -55,11 +56,7 @@ resource "aws_iam_policy" "ecs-policy" {
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
         "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "cloudwatch:PutMetricData",
-        "cloudwatch:GetMetricStatistics",
-        "cloudwatch:ListMetrics",
-        "ec2:DescribeTags"
+        "logs:PutLogEvents"
       ],
       "Resource": "*"
     }
@@ -68,10 +65,19 @@ resource "aws_iam_policy" "ecs-policy" {
 EOF
 }
 
+resource "aws_iam_policy" "custom-ecs-policy" {
+  name_prefix = "${replace(format("%.102s", replace("tf-ECSInPol-${var.name}-", "_", "-")), "/\\s/", "-")}"
+  description = "A terraform created policy for ECS"
+  path        = "${var.iam_path}"
+  count       = "${var.use_custom_iam_policy}"
+
+  policy = "${var.custom_iam_policy}"
+}
+
 resource "aws_iam_policy_attachment" "attach-ecs" {
   name       = "ecs-attachment"
   roles      = ["${aws_iam_role.ecs-role.name}"]
-  policy_arn = "${aws_iam_policy.ecs-policy.arn}"
+  policy_arn = "${element(concat(aws_iam_policy.ecs-policy.*.arn, aws_iam_policy.custom-ecs-policy.*.arn), 0)}"
 }
 
 # IAM Resources for Consul and Registrator Agents

--- a/iam.tf
+++ b/iam.tf
@@ -55,7 +55,11 @@ resource "aws_iam_policy" "ecs-policy" {
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "cloudwatch:PutMetricData",
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "ec2:DescribeTags"
       ],
       "Resource": "*"
     }

--- a/iam.tf
+++ b/iam.tf
@@ -35,7 +35,7 @@ resource "aws_iam_policy" "ecs-policy" {
   name_prefix = "${replace(format("%.102s", replace("tf-ECSInPol-${var.name}-", "_", "-")), "/\\s/", "-")}"
   description = "A terraform created policy for ECS"
   path        = "${var.iam_path}"
-  count       = "${1 - var.use_custom_iam_policy}"
+  count       = "${length(var.custom_iam_policy) > 0 ? 0 : 1}"
 
   policy = <<EOF
 {
@@ -69,7 +69,7 @@ resource "aws_iam_policy" "custom-ecs-policy" {
   name_prefix = "${replace(format("%.102s", replace("tf-ECSInPol-${var.name}-", "_", "-")), "/\\s/", "-")}"
   description = "A terraform created policy for ECS"
   path        = "${var.iam_path}"
-  count       = "${var.use_custom_iam_policy}"
+  count       = "${length(var.custom_iam_policy) > 0 ? 1 : 0}"
 
   policy = "${var.custom_iam_policy}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,16 @@ variable "iam_path" {
   description = "IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /"
 }
 
+variable "use_custom_iam_policy" {
+  default     = false
+  description = "Bool to switch to a custom IAM policy, disabled by default"
+}
+
+variable "custom_iam_policy" {
+  default     = "{}"
+  description = "Custom IAM policy to be used"
+}
+
 variable "instance_type" {
   default     = "t2.micro"
   description = "AWS Instance type, if you change, make sure it is compatible with AMI, not all AMIs allow all instance types "

--- a/variables.tf
+++ b/variables.tf
@@ -59,14 +59,9 @@ variable "iam_path" {
   description = "IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /"
 }
 
-variable "use_custom_iam_policy" {
-  default     = false
-  description = "Bool to switch to a custom IAM policy, disabled by default"
-}
-
 variable "custom_iam_policy" {
-  default     = "{}"
-  description = "Custom IAM policy to be used"
+  default     = ""
+  description = "Custom IAM policy (JSON). If set will overwrite the default one"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
Hi, I've added some actions so that the Instance could report additional metrics (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html). I need memory info so this is handy, and since an Instance can have only one IAM role it's hopefuly a good place to add to :)
All is needed now is a cron job that pushes them, so this is my ugly additional_user_data:
"yum install -y unzip perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https perl-Digest-SHA && curl http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip -O && unzip CloudWatchMonitoringScripts-1.2.1.zip -d /opt/  && echo '*/5 * * * * ec2-user /opt/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-used-incl-cache-buff --mem-avail --from-cron --verbose' >> /etc/crontab"