### PR TITLE
Update memoryReservation for consul agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: if [ `terraform fmt | wc -c` -ne 0 ]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: "get tflint"
-          command: apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.4.2/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
+          command: apk update && apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.4.2/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
       - run:
           name: "install tflint"
           command: mkdir -p /usr/local/tflint/bin ; export PATH=/usr/local/tflint/bin:$PATH ; install tflint /usr/local/tflint/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: if [ `terraform fmt | wc -c` -ne 0 ]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: "get tflint"
-          command: apk update && apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.4.2/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
+          command: apk update && apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.5.4/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
       - run:
           name: "install tflint"
           command: mkdir -p /usr/local/tflint/bin ; export PATH=/usr/local/tflint/bin:$PATH ; install tflint /usr/local/tflint/bin

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ extra_tags = [
 
 - `consul_image` - Image to use when deploying consul, defaults to the hashicorp consul image
 - `registrator_image` - Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest
+- `consul_memory_reservation` - The soft limit (in MiB) of memory to reserve for the container, defaults 20
+- `registrator_memory_reservation` - The soft limit (in MiB) of memory to reserve for the container, defaults 20
 - `enable_agents` - Enable Consul Agent and Registrator tasks on each ECS Instance. Defaults to false
 
 Usage

--- a/consul_agent.tf
+++ b/consul_agent.tf
@@ -2,12 +2,14 @@ data "template_file" "consul" {
   template = "${file("${path.module}/templates/consul.json")}"
 
   vars {
-    env                   = "${aws_ecs_cluster.cluster.name}"
-    image                 = "${var.consul_image}"
-    registrator_image     = "${var.registrator_image}"
-    awslogs_group         = "consul-agent-${aws_ecs_cluster.cluster.name}"
-    awslogs_stream_prefix = "consul-agent-${aws_ecs_cluster.cluster.name}"
-    awslogs_region        = "${var.region}"
+    env                            = "${aws_ecs_cluster.cluster.name}"
+    image                          = "${var.consul_image}"
+    registrator_image              = "${var.registrator_image}"
+    consul_memory_reservation      = "${var.consul_memory_reservation}"
+    registrator_memory_reservation = "${var.registrator_memory_reservation}"
+    awslogs_group                  = "consul-agent-${aws_ecs_cluster.cluster.name}"
+    awslogs_stream_prefix          = "consul-agent-${aws_ecs_cluster.cluster.name}"
+    awslogs_region                 = "${var.region}"
   }
 }
 
@@ -42,11 +44,12 @@ resource "aws_cloudwatch_log_group" "consul" {
 }
 
 resource "aws_ecs_service" "consul" {
-  count           = "${var.enable_agents ? 1 : 0}"
-  name            = "consul-agent-${aws_ecs_cluster.cluster.name}"
-  cluster         = "${aws_ecs_cluster.cluster.id}"
-  task_definition = "${aws_ecs_task_definition.consul.arn}"
-  desired_count   = "${var.servers}"
+  count                              = "${var.enable_agents ? 1 : 0}"
+  name                               = "consul-agent-${aws_ecs_cluster.cluster.name}"
+  cluster                            = "${aws_ecs_cluster.cluster.id}"
+  task_definition                    = "${aws_ecs_task_definition.consul.arn}"
+  desired_count                      = "${var.servers}"
+  deployment_minimum_healthy_percent = "60"
 
   placement_constraints {
     type = "distinctInstance"

--- a/templates/consul.json
+++ b/templates/consul.json
@@ -2,7 +2,7 @@
         {
             "name": "consul_agent-${env}",
             "image": "${image}",
-            "memoryReservation": 512,
+            "memoryReservation": ${consul_memory_reservation},
             "environment": [
                 {
                     "name": "CONSUL_BIND_INTERFACE",
@@ -30,7 +30,7 @@
         {
             "name": "registrator-${env}",
             "image": "${registrator_image}",
-            "memoryReservation": 256,
+            "memoryReservation": ${registrator_memory_reservation},
             "command": [
               "-retry-attempts=10", "-retry-interval=1000", "consul://localhost:8500"
             ],

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "consul_image" {
 
 variable "consul_memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the container, defaults 20"
-  default     = "20"
+  default     = "32"
 }
 
 variable "docker_storage_size" {
@@ -108,7 +108,7 @@ variable "registrator_image" {
 
 variable "registrator_memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the container, defaults 20"
-  default     = "20"
+  default     = "32"
 }
 
 variable "security_group_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,11 @@ variable "consul_image" {
   default     = "consul:latest"
 }
 
+variable "consul_memory_reservation" {
+  description = "The soft limit (in MiB) of memory to reserve for the container, defaults 20"
+  default     = "20"
+}
+
 variable "docker_storage_size" {
   default     = "22"
   description = "EBS Volume size in Gib that the ECS Instance uses for Docker images and metadata "
@@ -99,6 +104,11 @@ variable "region" {
 variable "registrator_image" {
   default     = "gliderlabs/registrator:latest"
   description = "Image to use when deploying registrator agent, defaults to the gliderlabs registrator:latest image"
+}
+
+variable "registrator_memory_reservation" {
+  description = "The soft limit (in MiB) of memory to reserve for the container, defaults 20"
+  default     = "20"
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
This PR updates some of the defaults for the consul/registrator agents. In particular it sets the default mem reservation to lower so that consul and registrator don't dominate smaller instances