### PR TITLE
Adding windows support

### DIFF
--- a/templates/linux_user_data.tpl
+++ b/templates/linux_user_data.tpl
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo ECS_CLUSTER=${cluster_name} >> /etc/ecs/ecs.config
+echo 'OPTIONS="$${OPTIONS} --storage-opt dm.basesize=${docker_storage_size}G"' >> /etc/sysconfig/docker
+/etc/init.d/docker restart
+echo ECS_ENGINE_AUTH_TYPE=dockercfg >> /etc/ecs/ecs.config
+echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/": { "auth": "${dockerhub_token}", "email": "${dockerhub_email}"}}' >> /etc/ecs/ecs.config
+
+# Append addition user-data script
+${additional_user_data_script}

--- a/templates/windows_user_data.tpl
+++ b/templates/windows_user_data.tpl
@@ -1,0 +1,30 @@
+<script>
+  powershell.exe Set-ExecutionPolicy RemoteSigned -Force
+</script>
+<powershell>
+
+  Import-Module ECSTools
+  Initialize-ECSAgent -Cluster "${cluster_name}" -EnableTaskIAMRole
+
+  # We are assuming there is only one offline disk
+  $OfflineDisks = Get-Disk | Where-Object IsOffline –Eq $True
+
+  If ( $OfflineDisks ) {
+    $OfflineDisks | Set-Disk -IsOffline $False
+    $OfflineDisks | Set-Disk -IsReadOnly $False
+    $OfflineDisks | Initialize-Disk -PartitionStyle MBR
+    $OfflineDisks | New-Partition -UseMaximumSize -DriveLetter D
+    Get-Volume -DriveLetter D | Format-Volume -FileSystem NTFS
+
+    # Create the docker config and point to the new volume
+    mkdir 'd:/docker'
+    New-Item -Path 'C:\ProgramData\Docker\config\daemon.json' -Value '{ "data-root": "d:\\docker" }' -Force
+  }
+
+  # Restart service for settings to take effect
+  Restart-Service docker -Force
+
+  # Append addition user-data script
+  ${additional_user_data_script}
+
+</powershell>

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,8 @@ variable "user_data" {
 variable "vpc_id" {
   description = "The AWS VPC ID which you want to deploy your instances"
 }
+
+variable "ecs_platform" {
+  default = "linux"
+  description = "The OS of the underlying EC2 instances"
+}


### PR DESCRIPTION
While I'm still struggling with ECS for Windows I was able to use this to stand up a Windows ECS cluster with a second EBS volume and configure docker to use it.

I just created a var for "ecs_platform" and used conditionals to switch the EBS volume path and user_data scripts ( I split them into one for linux and one for Windows).

Let me know what you think.