### PR TITLE
add optional load_balancers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Module Input Variables
 - `min_servers`  - Minimum number of ECS Servers to start in the cluster - defaults to 1
 - `max_servers`  - Maximum number of ECS Servers to start in the cluster - defaults to 10
 - `instance_type` - AWS instance type - defaults to t2.micro
+- `load_balancers` - List of elastic load balancer (classic only) names to put in front of your instances - defaults to []
 - `iam_path` - IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /
 - `associate_public_ip_address` - assign a publicly-routable IP address to every instance in the cluster - default: `false`.
 - `docker_storage_size` - EBS Volume size in Gib that the ECS Instance uses for Docker images and metadata - defaults to 22

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "aws_autoscaling_group" "ecs" {
   max_size             = "${var.max_servers}"
   desired_capacity     = "${var.servers}"
   termination_policies = ["OldestLaunchConfiguration", "ClosestToNextInstanceHour", "Default"]
+  load_balancers       = ["${var.load_balancers}"]
 
   tags = [{
     key                 = "Name"

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "key_name" {
   description = "SSH key name in your AWS account for AWS instances."
 }
 
+variable "load_balancers" {
+  type        = "list"
+  default     = []
+  description = "A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers."
+}
+
 variable "min_servers" {
   description = "Minimum number of ECS servers to run."
   default     = 1


### PR DESCRIPTION
I noticed #25 already proposed this change, but it doesn't seem to be able to merge + provides additional changes. ECS's limitation of load balancing one port per service is the main justification for this change. 