### PR TITLE
Ignore changes to desired_capacity for aws_autoscaling_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_autoscaling_group" "ecs" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = ["desired_capacity"]
+    ignore_changes        = ["desired_capacity"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ resource "aws_autoscaling_group" "ecs" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["desired_capacity"]
   }
 }
 


### PR DESCRIPTION
The desired capacity of an autoscaling group can be changed externally due to autoscaling rules. This means that this Terraform resource should not try and change/overwrite this value when updating, as this could result in the number of instances being reduced below what is currently required.

From the Terraform docs:

> By default, Terraform detects any difference in the current settings of a real infrastructure object and plans to update the remote object to match configuration.
>
> In some rare cases, settings of a remote object are modified by processes outside of Terraform, which Terraform would then attempt to "fix" on the next run. In order to make Terraform share management responsibilities of a single object with a separate process, the ignore_changes meta-argument specifies resource attributes that Terraform should ignore when planning updates to the associated remote object.
>
> The arguments corresponding to the given attribute names are considered when planning a create operation, but are ignored when planning an update.

https://www.terraform.io/docs/configuration/resources.html#ignore_changes