### PR TITLE
(Feature) Add asg_delete_extra_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ extra_tags = [
 - `ami` - A specific AMI image to use, eg `ami-95f8d2f3`. Defaults to the latest ECS optimized Amazon Linux AMI.
 - `ami_version` - Specific version of the Amazon ECS AMI to use (e.g. `2016.09`). Defaults to `*`. Ignored if `ami` is specified.
 - `heartbeat_timeout` - Heartbeat Timeout setting for how long it takes for the graceful shutdown hook takes to timeout. This is useful when deploying clustered applications like consul that benifit from having a deploy between autoscaling create/destroy actions. Defaults to 180"
+- `asg_delete_extra_timeout` - Extra time that `terraform apply` will wait for ASG deletion (default 600). This is added on top of `heartbeat_timeout`. This variable is customizable for when the instances take longer than 600sec to shut down once shutdown is initiated.
 - `security_group_ids` - a list of security group IDs to apply to the launch configuration
 - `user_data` - The instance user data (e.g. a `cloud-init` config) to use in the `aws_launch_configuration`
 -  custom_iam_policy -  JSON containing the custom IAM policy for ECS nodes. Will overwrite the default one if set.

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,10 @@ resource "aws_autoscaling_group" "ecs" {
   lifecycle {
     create_before_destroy = true
   }
+
+  timeouts {
+    delete = "${var.heartbeat_timeout + var.asg_delete_extra_timeout}"
+  }
 }
 
 resource "aws_security_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_autoscaling_group" "ecs" {
   }
 
   timeouts {
-    delete = "${var.heartbeat_timeout + var.asg_delete_extra_timeout}"
+    delete = "${var.heartbeat_timeout + var.asg_delete_extra_timeout}s"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,11 @@ variable "heartbeat_timeout" {
   default     = "180"
 }
 
+variable "asg_delete_extra_timeout" {
+  description = "Extra time that `terraform apply` will wait for ASG deletion (default 600). This is added on top of `heartbeat_timeout`. This variable is customizable for when the instances take longer than 600sec to shut down once shutdown is initiated."
+  default     = "600"
+}
+
 variable "iam_path" {
   default     = "/"
   description = "IAM path, this is useful when creating resources with the same name across multiple regions. Defaults to /"


### PR DESCRIPTION
This prevents `terraform apply` from timing out when cycling the ASG and heartbeat_timeout is close to or above 10 minutes. (The terraform aws_autoscaling_group default timeout for delete is 10 minutes.)

This new variable `asg_delete_extra_timeout` is added to `heartbeat_timeout` and used in a `timeouts` block on the ASG.