### PR TITLE
Add Root Block Device Var with 100GB default

### DIFF
--- a/graceful_shutdown.tf
+++ b/graceful_shutdown.tf
@@ -10,6 +10,7 @@ resource "aws_autoscaling_lifecycle_hook" "graceful_shutdown_asg_hook" {
 }
 
 resource "aws_autoscaling_lifecycle_hook" "graceful_shutdown_asg_hook_second" {
+  count                  = "${var.second_asg_servers > 0 ? 1 : 0}"
   name                   = "graceful_shutdown_asg"
   autoscaling_group_name = "${aws_autoscaling_group.ecs_second.name}"
   default_result         = "CONTINUE"

--- a/graceful_shutdown.tf
+++ b/graceful_shutdown.tf
@@ -8,3 +8,11 @@ resource "aws_autoscaling_lifecycle_hook" "graceful_shutdown_asg_hook" {
   heartbeat_timeout      = "${var.heartbeat_timeout}"
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
 }
+
+resource "aws_autoscaling_lifecycle_hook" "graceful_shutdown_asg_hook_second" {
+  name                   = "graceful_shutdown_asg"
+  autoscaling_group_name = "${aws_autoscaling_group.ecs_second.name}"
+  default_result         = "CONTINUE"
+  heartbeat_timeout      = "${var.heartbeat_timeout}"
+  lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
+}

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,10 @@ resource "aws_launch_configuration" "ecs" {
   lifecycle {
     create_before_destroy = true
   }
+
+  root_block_device {
+    volume_size = "${var.aws_ecs_root_block_size}"
+  }
 }
 
 resource "aws_autoscaling_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,10 @@ resource "aws_launch_configuration" "ecs_second" {
   lifecycle {
     create_before_destroy = true
   }
+
+  root_block_device {
+    volume_size = "${var.aws_ecs_root_block_size}"
+  }
 }
 
 resource "aws_autoscaling_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "aws_autoscaling_group" "ecs" {
 # Optional Second ASG
 resource "aws_autoscaling_group" "ecs_second" {
   count                = "${var.second_asg_servers > 0 ? 1 : 0}"
-  name_prefix          = "asg-second-${aws_launch_configuration.ecs.name}-"
+  name_prefix          = "asg-second-${aws_launch_configuration.ecs_second.name}-"
   vpc_zone_identifier  = ["${var.subnet_id}"]
   launch_configuration = "${aws_launch_configuration.ecs_second.name}"
   min_size             = "${var.second_asg_min_servers}"

--- a/main.tf
+++ b/main.tf
@@ -72,10 +72,6 @@ resource "aws_launch_configuration" "ecs_second" {
   lifecycle {
     create_before_destroy = true
   }
-
-  root_block_device {
-    volume_size = "${var.aws_ecs_root_block_size}"
-  }
 }
 
 resource "aws_autoscaling_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -46,10 +46,6 @@ resource "aws_launch_configuration" "ecs" {
   lifecycle {
     create_before_destroy = true
   }
-
-  root_block_device {
-    volume_size = "${var.aws_ecs_root_block_size}"
-  }
 }
 
 resource "aws_autoscaling_group" "ecs" {

--- a/main.tf
+++ b/main.tf
@@ -85,14 +85,14 @@ resource "aws_security_group" "ecs" {
     from_port   = 0
     to_port     = 65535
     protocol    = "tcp"
-    cidr_blocks = "${var.allowed_cidr_blocks}"
+    cidr_blocks = ["${var.allowed_cidr_blocks}"]
   }
 
   ingress {
     from_port   = 0
     to_port     = 65535
     protocol    = "udp"
-    cidr_blocks = "${var.allowed_cidr_blocks}"
+    cidr_blocks = ["${var.allowed_cidr_blocks}"]
   }
 
   egress {

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,36 @@ resource "aws_launch_configuration" "ecs" {
   }
 }
 
+# Optional Second Launch Config for the optional Second ASG
+resource "aws_launch_configuration" "ecs_second" {
+  count                       = "${var.second_asg_servers > 0 ? 1 : 0}"
+  name_prefix                 = "${coalesce(var.name_prefix, "ecs-second-${var.name}-")}"
+  image_id                    = "${var.second_asg_ami == "" ? format("%s", data.aws_ami.ecs_ami.id) : var.second_asg_ami}"   # Workaround until 0.9.6
+  instance_type               = "${var.instance_type}"
+  key_name                    = "${var.key_name}"
+  iam_instance_profile        = "${aws_iam_instance_profile.ecs_profile.name}"
+  security_groups             = ["${concat(list(aws_security_group.ecs.id), var.security_group_ids)}"]
+  associate_public_ip_address = "${var.associate_public_ip_address}"
+  spot_price                  = "${var.spot_bid_price}"
+
+  ebs_block_device {
+    device_name           = "${var.ebs_block_device}"
+    volume_size           = "${var.docker_storage_size}"
+    volume_type           = "gp2"
+    delete_on_termination = true
+  }
+
+  user_data = "${coalesce(var.user_data, data.template_file.user_data.rendered)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  root_block_device {
+    volume_size = "${var.aws_ecs_root_block_size}"
+  }
+}
+
 resource "aws_autoscaling_group" "ecs" {
   name_prefix          = "asg-${aws_launch_configuration.ecs.name}-"
   vpc_zone_identifier  = ["${var.subnet_id}"]
@@ -81,7 +111,7 @@ resource "aws_autoscaling_group" "ecs_second" {
   count                = "${var.second_asg_servers > 0 ? 1 : 0}"
   name_prefix          = "asg-second-${aws_launch_configuration.ecs.name}-"
   vpc_zone_identifier  = ["${var.subnet_id}"]
-  launch_configuration = "${aws_launch_configuration.ecs.name}"
+  launch_configuration = "${aws_launch_configuration.ecs_second.name}"
   min_size             = "${var.second_asg_min_servers}"
   max_size             = "${var.second_asg_max_servers}"
   desired_capacity     = "${var.second_asg_servers}"

--- a/variables.tf
+++ b/variables.tf
@@ -100,8 +100,18 @@ variable "min_servers" {
   default     = 1
 }
 
+variable "second_asg_min_servers" {
+  description = "Minimum number of ECS servers to run in the Second ASG."
+  default     = 1
+}
+
 variable "max_servers" {
   description = "Maximum number of ECS servers to run."
+  default     = 10
+}
+
+variable "second_asg_max_servers" {
+  description = "Maximum number of ECS servers to run in the Second ASG."
   default     = 10
 }
 
@@ -137,6 +147,11 @@ variable "security_group_ids" {
 variable "servers" {
   default     = "1"
   description = "The number of servers to launch."
+}
+
+variable "second_asg_servers" {
+  default     = "0"
+  description = "The number of servers to launch in the Second ASG, default 0 (in which case the Second ASG is not created)."
 }
 
 variable "spot_bid_price" {

--- a/variables.tf
+++ b/variables.tf
@@ -167,3 +167,8 @@ variable "enabled_metrics" {
   type        = "list"
   default     = []
 }
+
+variable "aws_ecs_root_block_size" {
+  description = "The size of the aws_launch_configuration.ecs root_block_device volume in gigabytes."
+  default = "100"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -186,3 +186,8 @@ variable "enabled_metrics" {
   type        = "list"
   default     = []
 }
+
+variable "aws_ecs_root_block_size" {
+  description = "The size of the aws_launch_configuration.ecs root_block_device volume in gigabytes."
+  default = "100"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -170,5 +170,5 @@ variable "enabled_metrics" {
 
 variable "aws_ecs_root_block_size" {
   description = "The size of the aws_launch_configuration.ecs root_block_device volume in gigabytes."
-  default = "100"
+  default     = "100"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -167,8 +167,3 @@ variable "enabled_metrics" {
   type        = "list"
   default     = []
 }
-
-variable "aws_ecs_root_block_size" {
-  description = "The size of the aws_launch_configuration.ecs root_block_device volume in gigabytes."
-  default     = "100"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,10 @@ variable "ami" {
   default = ""
 }
 
+variable "second_asg_ami" {
+  default = ""
+}
+
 variable "ami_version" {
   default = "*"
 }


### PR DESCRIPTION
Feature to extract root block device size into a variable. Setting 100GB as the default value. 

Done to address an issue where root block device fills up and needs to be manually emptied of erroneous logs. 